### PR TITLE
wrong place about console

### DIFF
--- a/files/isolinux/txt.cfg
+++ b/files/isolinux/txt.cfg
@@ -2,4 +2,4 @@ default install
 label install
   menu label ^Install Ubuntu Server
   kernel /install/vmlinuz
-  append vga=normal initrd=/install/initrd.gz -- console=tty0 console=ttyS0,115200n8 nosplash debug –
+  append vga=788 initrd=/install/initrd.gz console=tty0 console=ttyS0,115200n8  –--


### PR DESCRIPTION
 console=tty0 console=ttyS0,115200n8 Should be before --
alse change vga=788 is not necessary.
The command after -- will not use，but will only pass to the new system's  GRUB_CMDLINE_LINUX_DEFAULT
I did many test about console, and must be  console=tty0 console=ttyS0,115200n8, not console=ttyS0,115200n8  console=tty0 .